### PR TITLE
Refactor Motion to use an interface

### DIFF
--- a/src/game/Linear.ts
+++ b/src/game/Linear.ts
@@ -1,0 +1,13 @@
+import Vector2D from "@/game/Vector2D";
+import { Motion } from './Physics';
+export class Linear implements Motion {
+    velocity: Vector2D;
+    constructor(velocity?: Vector2D) {
+        this.velocity = velocity || new Vector2D(0, 0);
+    }
+    nextState(currentLocation: Vector2D, dt: number): [Vector2D, Motion] {
+        const delta = this.velocity.multiply(dt);
+        const newLocation = currentLocation.add(delta);
+        return [newLocation, this];
+    }
+}

--- a/src/game/Orbiting.ts
+++ b/src/game/Orbiting.ts
@@ -1,0 +1,29 @@
+import Vector2D from "@/game/Vector2D";
+import { Motion, Physical } from './Physics';
+/**
+ * Orbital motion.
+ */
+export class Orbiting implements Motion {
+    /**
+     * The object this entity is orbiting around.
+     */
+    parent: Physical;
+    angularVelocity: number;
+    isAntiClockwise: boolean;
+    radius: number;
+    constructor(parent: Physical, angularVelocity: number, radius: number, isAntiClockwise: boolean = false) {
+        this.parent = parent;
+        this.angularVelocity = angularVelocity;
+        this.radius = radius;
+        this.isAntiClockwise = isAntiClockwise;
+    }
+    nextState(currentLocation: Vector2D, dt: number): [Vector2D, Motion] {
+        const parentLocation = this.parent.physics.currentLocation;
+        const angle = currentLocation.sub(parentLocation).angle;
+        const newAngle = angle + this.angularVelocity * dt;
+        const dx = this.radius * Math.cos(newAngle);
+        const dy = this.radius * Math.sin(newAngle);
+        const newLocation = new Vector2D(parentLocation.x + dx, parentLocation.y + dy);
+        return [newLocation, this];
+    }
+}

--- a/src/game/Physics.ts
+++ b/src/game/Physics.ts
@@ -52,50 +52,6 @@ export interface Motion {
     nextState(currentLocation: Vector2D, dt: number): [Vector2D, Motion];
 }
 
-export class Linear implements Motion {
-    velocity: Vector2D;
-    constructor(velocity?: Vector2D) {
-        this.velocity = velocity || new Vector2D(0, 0);
-    }
-    nextState(currentLocation: Vector2D, dt: number): [Vector2D, Motion] {
-        const delta = this.velocity.multiply(dt);
-        const newLocation = currentLocation.add(delta);
-        return [newLocation, this];
-    }
-}
-
-/**
- * Orbital motion.
- */
-export class Orbiting implements Motion {
-    /**
-     * The object this entity is orbiting around.
-     */
-    parent: Physical;
-    angularVelocity: number;
-    isAntiClockwise: boolean;
-    radius: number;
-
-    constructor(parent: Physical, angularVelocity: number, radius: number, isAntiClockwise: boolean = false) {
-        this.parent = parent;
-        this.angularVelocity = angularVelocity;
-        this.radius = radius;
-        this.isAntiClockwise = isAntiClockwise;
-    }
-
-    nextState(currentLocation: Vector2D, dt: number): [Vector2D, Motion] {
-        const parentLocation = this.parent.physics.currentLocation;
-        const angle = currentLocation.sub(parentLocation).angle;
-        const newAngle = angle + this.angularVelocity * dt;
-
-        const dx = this.radius * Math.cos(newAngle);
-        const dy = this.radius * Math.sin(newAngle);
-
-        const newLocation = new Vector2D(parentLocation.x + dx, parentLocation.y + dy);
-        return [newLocation, this];
-    }
-}
-
 /**
  * A type guard for checking whether something implements the Physical
  * interface.

--- a/src/game/Physics.ts
+++ b/src/game/Physics.ts
@@ -13,29 +13,9 @@ export function updateWorld(world: World, deltaTime: number) {
 function updatePhysicalObject(entity: Physical, dt: number) {
     const p = entity.physics;
 
-    if (p.motion instanceof Orbiting) {
-        p.currentLocation = updateOrbitalMotion(p.currentLocation, p.motion, dt);
-    } else if (p.motion instanceof Linear) {
-        p.currentLocation = updateLinearMotion(p.currentLocation, p.motion, dt);
-    } else {
-        throw "Well what type of motion is this then?!";
-    }
-}
-
-export function updateOrbitalMotion(currentLocation: Vector2D, motion: Orbiting, dt: number): Vector2D {
-    const parentLocation = motion.parent.physics.currentLocation;
-    const angle = currentLocation.sub(parentLocation).angle;
-    const newAngle = angle + motion.angularVelocity * dt;
-
-    const dx = motion.radius * Math.cos(newAngle);
-    const dy = motion.radius * Math.sin(newAngle);
-
-    return new Vector2D(parentLocation.x + dx, parentLocation.y + dy);
-}
-
-export function updateLinearMotion(currentLocation: Vector2D, motion: Linear, dt: number): Vector2D {
-    const delta = motion.velocity.multiply(dt);
-    return currentLocation.add(delta);
+    const [newLocation, motion] = p.motion.nextState(p.currentLocation, dt);
+    p.currentLocation = newLocation;
+    p.motion = motion;
 }
 
 /**

--- a/src/game/Planet.ts
+++ b/src/game/Planet.ts
@@ -1,5 +1,6 @@
 import Vector2D from './Vector2D';
-import { Physics, Linear, Physical } from './Physics';
+import { Physics, Physical } from './Physics';
+import { Linear } from "./Linear";
 import { Render, Renderable } from '@/game/Render';
 
 /**

--- a/src/game/Satellite.ts
+++ b/src/game/Satellite.ts
@@ -1,4 +1,5 @@
-import { Physics, Orbiting, Physical } from './Physics';
+import { Physics, Physical } from './Physics';
+import { Orbiting } from "./Orbiting";
 import { Renderable, Render } from './Render';
 
 export default class Satellite implements Physical, Renderable {

--- a/src/game/World.ts
+++ b/src/game/World.ts
@@ -1,4 +1,5 @@
-import { updateWorld, Linear } from '@/game/Physics';
+import { updateWorld } from '@/game/Physics';
+import { Linear } from "@/game/Linear";
 import Planet from "@/game/Planet";
 import Vector2D from "@/game/Vector2D";
 import { renderWorld } from "@/game/Render";

--- a/tests/unit/Physics.spec.ts
+++ b/tests/unit/Physics.spec.ts
@@ -1,4 +1,4 @@
-import { Linear, updateLinearMotion, updateOrbitalMotion, Orbiting } from '@/game/Physics';
+import { Orbiting, Linear } from '@/game/Physics';
 import Vector2D from '@/game/Vector2D';
 import Planet from '@/game/Planet';
 
@@ -12,7 +12,7 @@ describe('Linear motion', () => {
         const motion = new Linear(new Vector2D(1, 0));
         const initialPosition = new Vector2D(500, 100);
 
-        const newPosition = updateLinearMotion(initialPosition, motion, 2);
+        const [newPosition] = motion.nextState(initialPosition, 2);
 
         expect(newPosition.y).toBe(initialPosition.y);
         expect(newPosition.x).toBe(initialPosition.x + 2 * motion.velocity.x);
@@ -27,7 +27,7 @@ describe('Circular motion', () => {
         const motion = new Orbiting(parent, radsPerSecond, 100, true);
         const initialPosition = new Vector2D(motion.radius, 0);
 
-        const newPosition = updateOrbitalMotion(initialPosition, motion, 0.25);
+        const [newPosition] = motion.nextState(initialPosition, 0.25);
 
         const expectedPosition = new Vector2D(0, motion.radius);
         expect(newPosition.x).toBeCloseTo(expectedPosition.x);

--- a/tests/unit/Physics.spec.ts
+++ b/tests/unit/Physics.spec.ts
@@ -1,4 +1,5 @@
-import { Orbiting, Linear } from '@/game/Physics';
+import { Linear } from "@/game/Linear";
+import { Orbiting } from "@/game/Orbiting";
 import Vector2D from '@/game/Vector2D';
 import Planet from '@/game/Planet';
 


### PR DESCRIPTION
At some point we're going to want to let things transition between different `Motion`s (e.g. imagine `Orbiting` at 1km, then `ChangingOrbit` from 1km to 2km, then `Orbiting` at 2km). 

This PR changes `Motion` so instead of asking which type of motion an object has and trying to deal with each type manually, you ask the `Motion` to step forward `dt` and give you the new object location and `Motion`.